### PR TITLE
✨ feat(orchestration): add orchestrate_session loop, state model, and tests

### DIFF
--- a/core/classes.py
+++ b/core/classes.py
@@ -87,6 +87,17 @@ class TaskQueue(BaseModel):
         return field
 
 
+class OrchestrationState(BaseModel):
+    """Track state for the orchestration loop."""
+    goal: str
+    plan: List[ActionStep] = Field(default_factory=list)
+    tool_results: List[str] = Field(default_factory=list)
+    open_questions: List[str] = Field(default_factory=list)
+    done: bool = False
+    done_reason: Optional[str] = None
+    summary: Optional[str] = None
+
+
 class AbstractTool(abc.ABC):
     """Abstract base class for tools, providing common features and requiring specific methods."""
 

--- a/docs/analysis/architecture-comparison.md
+++ b/docs/analysis/architecture-comparison.md
@@ -1,0 +1,134 @@
+# Architecture Comparison: Meeseeks vs. Claude Code
+
+## Scope
+This document summarizes the architectural blocks in the Meeseeks Personal Assistant codebase and compares them with Claude Code patterns from DeepWiki. It focuses on orchestration, tool execution, extensibility, and context management so we can identify gaps and plan targeted fixes.
+
+## Meeseeks (Personal Assistant) Architecture Blocks
+
+### Entry Points / Interfaces
+- **REST API**: Flask-RESTX endpoint `/api/query` accepts a user query, generates an action plan, executes it, and returns the `TaskQueue` payload as JSON. The API enforces an API token before execution. (Files: `meeseeks-api/backend.py`.)
+- **Chat UI**: Streamlit chat collects user prompts, displays the action plan, executes the plan, and renders the aggregated response. (Files: `meeseeks-chat/chat_master.py`.)
+- **Home Assistant integration**: The custom HA conversation integration routes voice requests to the API (documented externally in the HA integration package, but the core pipeline is the same API/TaskMaster flow).
+
+### Planning & Orchestration
+- **Planner**: `generate_action_plan()` uses a system prompt + few-shot examples + a Pydantic output parser (`TaskQueue`) to structure the plan into `ActionStep` objects. It logs tracing metadata using Langfuse. (Files: `core/task_master.py`.)
+- **Executor**: `run_action_plan()` maps each `ActionStep` to a tool instance, runs the tool, and aggregates tool outputs into `task_result`. (Files: `core/task_master.py`.)
+
+### Schema & Validation
+- **ActionStep / TaskQueue** enforce allowed tool IDs (`home_assistant_tool`, `talk_to_user_tool`), allowed action types (`get`/`set`), and non-null arguments. (Files: `core/classes.py`.)
+
+### Tool Framework
+- **AbstractTool** handles model configuration, Langfuse tracing, caching, and `get`/`set` execution routing. (Files: `core/classes.py`.)
+- **HomeAssistant tool** builds a cache of entities/services, renders prompts for set/get flows, performs LLM-based structured calls for `set`, and summarises sensor context for `get`. (Files: `tools/integration/homeassistant.py`.)
+- **TalkToUser tool** returns a message verbatim to speak to the user and does not implement `get`. (Files: `tools/core/talk_to_user.py`.)
+
+### Prompting Policy
+- The action planner prompt defines valid tools, action types, and guidelines (e.g., avoid `talk_to_user_tool` after `get`). (Files: `prompts/action-planner.txt`.)
+
+## Claude Code Architectural Patterns (DeepWiki)
+
+The DeepWiki architecture overview for Claude Code describes a layered system design with more extensive orchestration, extensibility, and context management:
+
+### Orchestration & Agents
+- A **main agent** handles the user’s interactive thread, while **subagents** can be spawned for parallel/background tasks. A dedicated **plan agent** is used for multi-step planning in “plan mode.”
+- Task tools can spawn subagents with model/tool restrictions and report results back to the main agent.
+
+### Tool Execution & Permissions
+- Built-in tools include Bash, Read/Write/Search, LSP, Task, and AskUserQuestion, all protected by a **permission system** with wildcard rules (e.g., `Write(docs/*.md)`).
+- A permission dialog is triggered when no rule matches, and **PermissionRequest hooks** can auto-approve or deny requests.
+
+### Hooks & Lifecycle Interception
+- A hook system provides `PreToolUse`, `PostToolUse`, `SessionStart`, `Stop`, `PermissionRequest`, and other events. Hooks can inject context or modify tool input/output.
+
+### Context Management / Compaction
+- Session transcripts are persisted, and **auto-compaction** triggers at ~98% context utilization. The compaction result becomes the active summary when a session resumes. MCP tool descriptions can be deferred to reduce context load.
+
+### Extensibility (Plugins, Skills, MCP)
+- Plugins expose commands, agents, skills, hooks, and optional MCP server definitions.
+- MCP supports multiple transports (stdio/HTTP/SSE/OAuth) and can defer tool discovery through an `MCPSearch` mechanism when tool descriptions become too large.
+
+### Framework Options for MCP Integration (external references)
+- **LangChain MCP adapters**: provide adapter functions that convert MCP tools/prompts/resources into LangChain-native types and support a multi-server MCP client with stdio/HTTP/SSE/WebSocket transports (see the `langchain-mcp-adapters` DeepWiki overview).  
+- **PydanticAI MCP tools**: the PydanticAI docs list MCP tools under third-party integrations; these can be used for a Pydantic-first integration path alongside LangChain tools.
+
+## Aider (External Reference) Orchestration Signals
+- Aider is a Python CLI that sustains long-running coding sessions and includes built-in chat history handling plus summarization utilities for large histories (useful for session artifacts/compaction design).
+- The CLI runs a persistent loop around its core coder, showing how a minimal controller loop can keep the session alive without constant re-parsing of user prompts.
+
+## Observed Gaps / Missing Mechanisms in Meeseeks
+
+### 1) Orchestration Depth
+- **Current**: single-shot plan → execute → aggregate.
+- **Missing**: plan-mode or iterative planning; subagent spawning; background task management; re-planning on tool failures.
+
+### 2) Tool Governance & Permissions
+- **Current**: no explicit permission gating; the tool registry is hard-coded and always available.
+- **Missing**: rule-based permissions, human-in-the-loop approval, hook-based interception before tool use.
+
+### 3) Context & Session Management
+- **Current**: per-request stateless planner; Streamlit maintains a short in-memory buffer, but core doesn’t persist session transcripts or compact history.
+- **Missing**: transcript persistence, compaction rules, context budgets, and resume/fork operations.
+
+### 4) Extensibility
+- **Current**: tools are manually registered; no plugin/skill/hook discovery.
+- **Missing**: plugin manifests, hook/skill frontmatter, MCP configuration lifecycle, marketplace or project-local tool catalogs.
+
+### 5) Functional Reliability Patterns
+- **Current**: errors are logged per step but not used to drive adaptive behavior.
+- **Missing**: automated retries, tool fallback strategies, confidence thresholds, or tool-specific error remediation flows.
+
+## Targeted Fix Path (KISS/DRY)
+
+### Phase 1: Core Orchestration Upgrade (single agent → looped controller)
+**Goal:** replace single-shot planning with a minimal controller loop that preserves task state across turns and keeps the model grounded in tool results.
+
+**Inspiration (external):** Aider maintains chat history files and has a summarization helper for long histories, and its CLI runs a continuous loop that repeatedly invokes the core coder until completion. These patterns are useful for long-running workflows and for preventing loss of task context.
+
+**Controller loop contract (minimal surface):**
+- **Inputs:** user request, prior loop state (if any), current session summary.
+- **Loop phases:** `plan → act → observe → decide`.
+- **Outputs:** updated loop state, tool results, optional user-facing response, and a completion flag.
+
+**Proposed loop state (lightweight JSON structure):**
+- `goal`: normalized user intent.
+- `plan`: current ordered list of `ActionStep` tasks (can be revised).
+- `tool_results`: last N tool outputs with timestamps.
+- `open_questions`: clarifications needed for progress.
+- `done`: boolean + reason (success, blocked, needs user input).
+- `summary`: rolling summary used for compaction.
+
+**Key behaviors to implement (KISS):**
+1. **Action plan can be revised** after tool results (e.g., if a tool fails or reveals new constraints).
+2. **Decision gate** determines whether to continue looping, ask user, or terminate.
+3. **Observation step** is just “summarize last tool output + update state.”
+4. **Short-term memory** is the loop state; **long-term memory** is the session transcript (Phase 3).
+
+**Minimal code changes to start (order of operations):**
+1. Wrap `generate_action_plan()` + `run_action_plan()` inside a new `orchestrate_session()` loop (in `core/task_master.py`).
+2. Persist loop state in memory for chat/API sessions (later to disk).
+3. Add a small completion check (e.g., `done` if no remaining steps or user question answered).
+4. Keep `ActionStep` + `TaskQueue` schema as-is, but allow re-generation of `TaskQueue` when needed.
+
+**Why this is the most leverage:** the looped controller is the core enabler for long-running, coherent conversations, and it unblocks later improvements (MCP tools, session artifacts, compaction) without major schema changes.
+
+### Phase 2: MCP Integration (minimal surface, maximum leverage)
+- Add MCP client support using **LangChain MCP adapters** (bridge MCP tools/prompts/resources into LangChain `BaseTool`/messages). This gives us tool discovery across multiple servers with minimal local code.
+- Optionally, add **PydanticAI MCP client** as an alternative path when a Pydantic-first stack is preferred (MCP tooling is first-class in PydanticAI docs and can coexist with LangChain-based orchestration).
+- Start with a **single MCP server** configured via a lightweight JSON config to prove the integration before expanding.
+
+### Phase 3: Session Artifacts & Compaction
+- Persist **transcripts (JSONL)** per session and add a manual `/compact` command.
+- Add **auto-compaction** once transcripts exist to keep long-running sessions within model context (mirrors Claude Code’s approach).
+
+### Phase 4: Session Management (resume/fork/branch)
+- Support **resume** (load transcripts + compact summary), **fork** (branch a session for experimentation), and **tagging** (for session lookup).
+- Keep the implementation small: a session index file + transcript store.
+
+### Phase 5: Extensibility Entry Point
+- Add a basic registry/manifest for tools so new MCP tools or local tools can be enabled without code edits. Avoid a marketplace at first.
+
+## Next Questions to Drive Implementation
+1. Should Meeseeks prioritize **parallel subagents** or a **single-agent iterative plan/act loop** first?
+2. What are the **minimum permissions** that must require human confirmation (e.g., `set` vs. `get`)?
+3. Do we need **session persistence** across chat and API immediately, or only for chat?
+4. Should tool discovery stay **static** for now, or move to a **manifest-driven registry** in Phase 4?

--- a/docs/analysis/command-log.md
+++ b/docs/analysis/command-log.md
@@ -1,0 +1,54 @@
+# Command Log (Architecture Review)
+
+Commands executed during the architecture review:
+
+- `ls`
+- `find .. -name AGENTS.md -print`
+- `uvx remote-mcp-cli list Codex-Tools | grep -i "wiki\|git\|guide\|help"`
+- `uvx remote-mcp-cli call Codex-Tools Deepwiki-OSS-read_wiki_structure '{"repoName":"anthropics/claude-code"}'`
+- `uvx remote-mcp-cli call Codex-Tools Deepwiki-OSS-ask_question '{"repoName":"anthropics/claude-code","question":"Summarize Claude Code architecture (orchestration, planning/acting, context management, tool/MCP integration, hooks, plugins/skills/agents). Provide key components and data flow."}'`
+- `uvx remote-mcp-cli call Codex-Tools GitHub-Repos-get_repository_tree '{"owner":"anthropics","repo":"claude-code","ref":"main"}'`
+- `sed -n '1,200p' README.md`
+- `rg -n "Architecture|architecture|orchestration|planner|agent|mcp|tool" docs core prompts meeseeks-api meeseeks-chat | head -n 200`
+- `sed -n '1,220p' core/task_master.py`
+- `sed -n '1,260p' core/classes.py`
+- `sed -n '1,220p' core/common.py`
+- `sed -n '1,260p' tools/integration/homeassistant.py`
+- `sed -n '260,620p' tools/integration/homeassistant.py`
+- `sed -n '1,260p' tools/core/talk_to_user.py`
+- `sed -n '1,260p' meeseeks-api/backend.py`
+- `ls meeseeks-chat`
+- `sed -n '1,260p' meeseeks-chat/chat_master.py`
+- `ls docs`
+- `uvx remote-mcp-cli call Codex-Tools GitHub-Repos-get_repository_tree '{"owner":"anthropics","repo":"claude-code","ref":"main","path":".claude"}'`
+- `uvx remote-mcp-cli call Codex-Tools GitHub-Repos-search_code '{"query":"repo:anthropics/claude-code architecture"}'`
+- `uvx remote-mcp-cli call Codex-Tools GitHub-Repos-get_file_contents '{"owner":"anthropics","repo":"claude-code","path":"README.md","ref":"main"}'`
+- `uvx remote-mcp-cli call Codex-Tools GitHub-Repos-get_file_contents '{"owner":"anthropics","repo":"claude-code","path":"plugins/README.md","ref":"main"}'`
+- `uvx remote-mcp-cli list Codex-Tools`
+- `uvx remote-mcp-cli list Codex-Tools | grep -i "wiki\|doc\|help\|guide"`
+- `uvx remote-mcp-cli call Codex-Tools Deepwiki-OSS-read_wiki_structure '{"repoName":"anthropics/claude-code"}'`
+- `uvx remote-mcp-cli call Codex-Tools Deepwiki-OSS-read_wiki_contents '{"repoName":"anthropics/claude-code"}'`
+- `uvx remote-mcp-cli call Codex-Tools Deepwiki-OSS-ask_question '{"repoName":"anthropics/claude-code","question":"Summarize the orchestration flow (planner/agent/task tool), including how subagents are spawned and how execution results are fed back to the main agent."}'`
+- `uvx remote-mcp-cli call Codex-Tools Deepwiki-OSS-ask_question '{"repoName":"anthropics/claude-code","question":"Detail the tool permission system and how hooks intercept tool calls (PreToolUse/PostToolUse/PermissionRequest)."}'`
+- `uvx remote-mcp-cli call Codex-Tools Deepwiki-OSS-ask_question '{"repoName":"anthropics/claude-code","question":"Explain the context window management and compaction strategy, including triggers, stored artifacts, and how summaries are used."}'`
+- `uvx remote-mcp-cli call Codex-Tools Deepwiki-OSS-ask_question '{"repoName":"anthropics/claude-code","question":"Describe MCP server integration and deferred tool discovery (MCPSearch) plus how plugins/skills/agents register MCP configs."}'`
+- `uvx remote-mcp-cli call Codex-Tools Deepwiki-OSS-ask_question '{"repoName":"anthropics/claude-code","question":"What is the agent system (main agent, subagents, plan agent) and how does it coordinate tool execution and results?"}'`
+- `uvx remote-mcp-cli call Codex-Tools Deepwiki-OSS-ask_question '{"repoName":"anthropics/claude-code","question":"How do plugins/skills/hooks integrate with the core execution loop, and what lifecycle events are available?"}'`
+- `uvx remote-mcp-cli call Codex-Tools Deepwiki-OSS-read_wiki_structure '{"repoName":"bearlike/Personal-Assistant"}'`
+- `uvx remote-mcp-cli call Codex-Tools Deepwiki-OSS-read_wiki_contents '{"repoName":"bearlike/Personal-Assistant"}'`
+- `uvx remote-mcp-cli call Codex-Tools Deepwiki-OSS-ask_question '{"repoName":"bearlike/Personal-Assistant","question":"Summarize the action planning + execution pipeline, and list the concrete tool registry and schemas enforced in code."}'`
+- `uvx remote-mcp-cli call Codex-Tools Deepwiki-OSS-ask_question '{"repoName":"bearlike/Personal-Assistant","question":"What are the main architectural components and data flow from UI/API to tools, and where are schemas enforced?"}'`
+- `uvx remote-mcp-cli call Codex-Tools Deepwiki-OSS-ask_question '{"repoName":"bearlike/Personal-Assistant","question":"Describe the tool framework and how tools are instantiated and executed, including error handling."}'`
+- `uvx remote-mcp-cli list Codex-Tools | grep -i "wiki\|doc\|git"`
+- `uvx remote-mcp-cli call Codex-Tools GitHub-Repos-get_repository_tree '{"owner":"Aider-AI","repo":"aider","ref":"main"}'`
+- `uvx remote-mcp-cli call Codex-Tools GitHub-Repos-get_file_contents '{"owner":"Aider-AI","repo":"aider","path":"README.md","ref":"main"}'`
+- `uvx remote-mcp-cli call Codex-Tools GitHub-Repos-search_code '{"query":"repo:Aider-AI/aider orchestrator OR orchestration OR agent"}'`
+- `uvx remote-mcp-cli call Codex-Tools GitHub-Repos-search_code '{"query":"repo:Aider-AI/aider chat history"}'`
+- `uvx remote-mcp-cli call Codex-Tools GitHub-Repos-get_file_contents '{"owner":"Aider-AI","repo":"aider","path":"aider/history.py","ref":"main"}'`
+- `uvx remote-mcp-cli call Codex-Tools GitHub-Repos-get_file_contents '{"owner":"Aider-AI","repo":"aider","path":"aider/main.py","ref":"main"}'`
+
+Notes:
+- `Deepwiki-OSS-ask_question` returned an HTTP 401 Unauthorized error when called for `anthropics/claude-code`.
+- `Deepwiki-OSS-ask_question` intermittently returned HTTP 401 errors. Successful responses were received for Claude Code permission/hooks and context/compaction questions; other ask_question attempts failed.
+- `Internet-Search-web_url_read` initially failed due to malformed JSON arguments; retried with valid JSON.
+- `Deepwiki-OSS-ask_question` for `langchain-ai/langchain-mcp-adapters` returned HTTP 401 Unauthorized.

--- a/meeseeks-api/backend.py
+++ b/meeseeks-api/backend.py
@@ -24,7 +24,7 @@ sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 
 # Custom imports - Meeseeks core modules
 if True:
-    from core.task_master import generate_action_plan, run_action_plan
+    from core.task_master import orchestrate_session
     from core.classes import TaskQueue
     from core.common import get_logger
 
@@ -128,10 +128,7 @@ class MeeseeksQuery(Resource):
         logging.info("Received user query: %s", user_query)
 
         # Generate action plan from user query
-        task_queue: TaskQueue = generate_action_plan(user_query=user_query)
-
-        # Execute action plan
-        task_queue = run_action_plan(task_queue)
+        task_queue: TaskQueue = orchestrate_session(user_query=user_query)
         # Deep copy the variable into another variable
         task_result = deepcopy(task_queue.task_result)
         to_return = task_queue.dict()

--- a/meeseeks-chat/chat_master.py
+++ b/meeseeks-chat/chat_master.py
@@ -22,7 +22,7 @@ from langchain.memory import ConversationBufferWindowMemory
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 
 # Custom imports - Meeseeks core modules
-from core.task_master import generate_action_plan, run_action_plan
+from core.task_master import generate_action_plan, orchestrate_session
 from core.common import get_logger
 from core.classes import TaskQueue
 
@@ -43,7 +43,11 @@ def generate_action_plan_helper(user_input: str):
 
 def run_action_plan_helper(task_queue: TaskQueue):
     ai_response = []
-    task_queue = run_action_plan(task_queue)
+    task_queue = orchestrate_session(
+        user_query=task_queue.human_message or "",
+        model_name=None,
+        initial_task_queue=task_queue,
+    )
     for action_step in task_queue.action_steps:
         ai_response.append(action_step.result.content)
 

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -1,0 +1,212 @@
+import sys
+import types
+
+langchain_community = types.ModuleType("langchain_community")
+document_loaders = types.ModuleType("langchain_community.document_loaders")
+document_loaders.JSONLoader = object
+langchain_community.document_loaders = document_loaders
+sys.modules["langchain_community"] = langchain_community
+sys.modules["langchain_community.document_loaders"] = document_loaders
+
+langchain_openai = types.ModuleType("langchain_openai")
+langchain_openai.ChatOpenAI = object
+sys.modules["langchain_openai"] = langchain_openai
+
+langfuse = types.ModuleType("langfuse")
+langfuse_callback = types.ModuleType("langfuse.callback")
+langfuse_callback.CallbackHandler = object
+langfuse.callback = langfuse_callback
+sys.modules["langfuse"] = langfuse
+sys.modules["langfuse.callback"] = langfuse_callback
+
+langchain_core = types.ModuleType("langchain_core")
+langchain_core_messages = types.ModuleType("langchain_core.messages")
+langchain_core_messages_ai = types.ModuleType("langchain_core.messages.ai")
+langchain_core_api = types.ModuleType("langchain_core._api.beta_decorator")
+langchain_core_pydantic = types.ModuleType("langchain_core.pydantic_v1")
+
+try:
+    from pydantic import BaseModel, Field, validator  # type: ignore
+except Exception:  # pragma: no cover
+    class BaseModel:
+        def __init__(self, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    def Field(*args, **kwargs):  # noqa: N802 - mimic pydantic API
+        return None
+
+    def validator(*args, **kwargs):  # noqa: N802 - mimic pydantic API
+        def wrapper(func):
+            return func
+
+        return wrapper
+
+langchain_core_pydantic.BaseModel = BaseModel
+langchain_core_pydantic.Field = Field
+langchain_core_pydantic.validator = validator
+
+langchain_core_messages.SystemMessage = object
+langchain_core_messages.HumanMessage = object
+langchain_core_messages_ai.AIMessage = object
+langchain_core_api.LangChainBetaWarning = Warning
+
+langchain_core.messages = langchain_core_messages
+langchain_core.pydantic_v1 = langchain_core_pydantic
+langchain_core._api = types.ModuleType("langchain_core._api")
+langchain_core._api.beta_decorator = langchain_core_api
+
+sys.modules["langchain_core"] = langchain_core
+sys.modules["langchain_core.messages"] = langchain_core_messages
+sys.modules["langchain_core.messages.ai"] = langchain_core_messages_ai
+sys.modules["langchain_core._api.beta_decorator"] = langchain_core_api
+sys.modules["langchain_core.pydantic_v1"] = langchain_core_pydantic
+
+langchain = types.ModuleType("langchain")
+langchain_prompts = types.ModuleType("langchain.prompts")
+langchain_output_parsers = types.ModuleType("langchain.output_parsers")
+langchain_prompts.ChatPromptTemplate = object
+langchain_prompts.HumanMessagePromptTemplate = object
+langchain_output_parsers.PydanticOutputParser = object
+langchain.prompts = langchain_prompts
+langchain.output_parsers = langchain_output_parsers
+sys.modules["langchain"] = langchain
+sys.modules["langchain.prompts"] = langchain_prompts
+sys.modules["langchain.output_parsers"] = langchain_output_parsers
+
+dotenv = types.ModuleType("dotenv")
+dotenv.load_dotenv = lambda *args, **kwargs: None
+sys.modules["dotenv"] = dotenv
+
+jinja2 = types.ModuleType("jinja2")
+jinja2.Environment = object
+jinja2.FileSystemLoader = object
+sys.modules["jinja2"] = jinja2
+
+coloredlogs = types.ModuleType("coloredlogs")
+coloredlogs.install = lambda *args, **kwargs: None
+sys.modules["coloredlogs"] = coloredlogs
+
+tiktoken = types.ModuleType("tiktoken")
+
+class DummyEncoding:
+    def encode(self, string):
+        return list(string)
+
+tiktoken.get_encoding = lambda *args, **kwargs: DummyEncoding()
+sys.modules["tiktoken"] = tiktoken
+
+requests = types.ModuleType("requests")
+requests.exceptions = types.SimpleNamespace(RequestException=Exception)
+requests.get = lambda *args, **kwargs: types.SimpleNamespace(
+    raise_for_status=lambda: None, json=lambda: []
+)
+requests.post = lambda *args, **kwargs: types.SimpleNamespace(
+    raise_for_status=lambda: None, json=lambda: [], text=""
+)
+sys.modules["requests"] = requests
+
+from core.classes import ActionStep, TaskQueue
+from core.common import get_mock_speaker
+from core import task_master
+
+
+class Counter:
+    def __init__(self):
+        self.count = 0
+
+    def bump(self):
+        self.count += 1
+
+
+def make_task_queue(message: str) -> TaskQueue:
+    step = ActionStep(
+        action_consumer="talk_to_user_tool",
+        action_type="set",
+        action_argument=message,
+    )
+    return TaskQueue(action_steps=[step])
+
+
+def test_orchestrate_session_completes(monkeypatch):
+    generate_calls = Counter()
+    run_calls = Counter()
+
+    def fake_generate(*args, **kwargs):
+        generate_calls.bump()
+        return make_task_queue("say hi")
+
+    def fake_run(task_queue):
+        run_calls.bump()
+        MockSpeaker = get_mock_speaker()
+        task_queue.action_steps[0].result = MockSpeaker(content="done")
+        task_queue.task_result = "done"
+        return task_queue
+
+    monkeypatch.setattr(task_master, "generate_action_plan", fake_generate)
+    monkeypatch.setattr(task_master, "run_action_plan", fake_run)
+
+    task_queue = task_master.orchestrate_session("hello", max_iters=3)
+
+    assert task_queue.task_result == "done"
+    assert generate_calls.count == 1
+    assert run_calls.count == 1
+
+
+def test_orchestrate_session_replans_on_failure(monkeypatch):
+    generate_calls = Counter()
+    run_calls = Counter()
+
+    def fake_generate(*args, **kwargs):
+        generate_calls.bump()
+        return make_task_queue("say hi")
+
+    def fake_run(task_queue):
+        run_calls.bump()
+        if run_calls.count == 1:
+            task_queue.action_steps[0].result = None
+            task_queue.task_result = "failed"
+        else:
+            MockSpeaker = get_mock_speaker()
+            task_queue.action_steps[0].result = MockSpeaker(content="ok")
+            task_queue.task_result = "ok"
+        return task_queue
+
+    monkeypatch.setattr(task_master, "generate_action_plan", fake_generate)
+    monkeypatch.setattr(task_master, "run_action_plan", fake_run)
+
+    task_queue = task_master.orchestrate_session("hello", max_iters=2)
+
+    assert task_queue.task_result == "ok"
+    assert generate_calls.count == 2
+    assert run_calls.count == 2
+
+
+def test_orchestrate_session_max_iters(monkeypatch):
+    generate_calls = Counter()
+    run_calls = Counter()
+
+    def fake_generate(*args, **kwargs):
+        generate_calls.bump()
+        return make_task_queue("say hi")
+
+    def fake_run(task_queue):
+        run_calls.bump()
+        task_queue.action_steps[0].result = None
+        task_queue.task_result = "failed"
+        return task_queue
+
+    monkeypatch.setattr(task_master, "generate_action_plan", fake_generate)
+    monkeypatch.setattr(task_master, "run_action_plan", fake_run)
+
+    task_queue, state = task_master.orchestrate_session(
+        "hello",
+        max_iters=1,
+        return_state=True,
+    )
+
+    assert task_queue.task_result == "failed"
+    assert state.done is False
+    assert state.done_reason == "max_iterations_reached"
+    assert generate_calls.count == 1
+    assert run_calls.count == 1


### PR DESCRIPTION
### Motivation
- Provide a minimal controller loop (plan → act → observe → decide) to support Phase 1 orchestration upgrades and enable iterative re-planning on tool failures.  
- Make orchestration signals explicit via an in-memory `OrchestrationState` so the controller can persist short-term loop state and completion reasons.  
- Wire existing API and chat flows to the new controller to reduce duplication and prepare for future session persistence and MCP integration.  

### Description
- Added `OrchestrationState` model to `core/classes.py` to track `goal`, `plan`, `tool_results`, `open_questions`, `done`, `done_reason`, and `summary`.  
- Implemented `orchestrate_session()` and helper `_action_steps_complete()` in `core/task_master.py`, which wraps `generate_action_plan()` + `run_action_plan()` in a loop with re-plan logic and optional `return_state`.  
- Updated `meeseeks-api/backend.py` and `meeseeks-chat/chat_master.py` to call `orchestrate_session()` (and preserved plan-display behavior for the chat UI).  
- Added `tests/test_orchestration.py` that mocks external dependencies (LangChain, tiktoken, requests, dotenv, etc.) and verifies completion, replan-on-failure, and max-iteration behaviors by monkeypatching `generate_action_plan` and `run_action_plan`.  

### Testing
- Ran `python -m pytest tests/test_orchestration.py` and all tests passed (`3 passed`).  
- Attempted `python -m flake8` but `flake8` is not installed in the environment so linting could not be executed.  
- Tests use tight unit-level mocks for LLM/tool dependencies to avoid network calls and validate the controller loop behavior deterministically.