### PR TITLE
📚 docs: add versioned MkDocs documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,68 @@
+name: docs
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install docs dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-docs.txt
+
+      - name: Verify mkdocstrings imports
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: python -c "import core.common; print(core.common.__name__)"
+
+      - name: Build docs
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: mkdocs build --strict
+
+      - name: Deploy dev docs
+        if: github.ref == 'refs/heads/main'
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: mike deploy --push dev
+
+      - name: Deploy versioned docs
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          DOCS_VERSION="${VERSION%.*}"
+          echo "DOCS_VERSION=$DOCS_VERSION" >> "$GITHUB_ENV"
+          mike deploy --push --update-aliases "$DOCS_VERSION" latest
+          mike set-default --push latest
+
+      - name: Smoke test versioned site
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          rm -rf site
+          git fetch origin gh-pages:gh-pages
+          git worktree add site gh-pages
+          test -d "site/$DOCS_VERSION"
+          test -d "site/latest"
+          git worktree remove site

--- a/README.md
+++ b/README.md
@@ -70,6 +70,49 @@ Optional feature that users can choose to install to further optimize their expe
 
 ---
 
+# Documentation 📚
+
+This repository ships a versioned documentation site built with MkDocs + Material and Mike.
+
+### Local documentation workflow
+
+1. Install documentation dependencies:
+
+   ```bash
+   pip install -r requirements-docs.txt
+   ```
+
+2. Serve docs locally:
+
+   ```bash
+   export PYTHONPATH="$PWD"
+   mkdocs serve
+   ```
+
+3. Build docs locally:
+
+   ```bash
+   export PYTHONPATH="$PWD"
+   mkdocs build --strict
+   ```
+
+### Deploying versioned docs with Mike
+
+For development docs (main branch):
+
+```bash
+export PYTHONPATH="$PWD"
+mike deploy dev
+```
+
+For release tags (for example, `v1.2.3` -> `1.2` with `latest` alias):
+
+```bash
+export PYTHONPATH="$PWD"
+mike deploy --update-aliases 1.2 latest
+mike set-default latest
+```
+
 # Contributing 👏
 
 We welcome contributions from the community to help improve Meeseeks. Whether you want to fix a bug, add a new feature, or integrate a new tool, your contributions are highly appreciated.
@@ -86,4 +129,3 @@ To contribute to Meeseeks, please follow these steps:
 If you encounter any bugs or have ideas for new features, please open an issue on our [issue tracker](https://github.com/bearlike/Personal-Assistant/issues). We appreciate detailed bug reports that include steps to reproduce the issue and any relevant error messages.
 
 Thank you for considering contributing to Meeseeks! Let's build cool stuff!
-

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,28 @@
+# Getting Started
+
+## Prerequisites
+
+- Python 3.10+
+- A virtual environment tool of your choice
+
+## Install documentation dependencies
+
+```bash
+pip install -r requirements-docs.txt
+```
+
+## Run the docs locally
+
+```bash
+export PYTHONPATH="$PWD"
+mkdocs serve
+```
+
+The documentation will be available at <http://127.0.0.1:8000/>.
+
+## Build the docs
+
+```bash
+export PYTHONPATH="$PWD"
+mkdocs build --strict
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,12 @@
+# Personal Assistant Documentation
+
+Welcome to the documentation for **Meeseeks: The Personal Assistant**. This site is built with MkDocs + Material and versioned with Mike so you can browse docs for both development and released versions.
+
+## What is Meeseeks?
+
+Meeseeks is a multi-agent assistant that breaks complex user requests into smaller actions, runs them through tools, and provides a consolidated response. This documentation covers how to run the project locally and how to explore the core APIs.
+
+## Docs Sections
+
+- [Getting Started](getting-started.md) for local setup and development tips.
+- [Reference](reference.md) for API documentation generated from the source code.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,7 @@
+# API Reference
+
+## Core utilities
+
+::: core.common
+    options:
+      heading_level: 2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,27 @@
+site_name: Personal Assistant
+site_description: Documentation for the Personal Assistant (Meeseeks) project.
+site_url: https://bearlike.github.io/personal-assistant/
+repo_url: https://github.com/bearlike/Personal-Assistant
+repo_name: bearlike/Personal-Assistant
+
+theme:
+  name: material
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths:
+            - .
+          options:
+            docstring_style: google
+
+extra:
+  version:
+    provider: mike
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Reference: reference.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,6 @@
+mkdocs-material
+mkdocstrings[python]
+mike
+coloredlogs
+jinja2
+tiktoken


### PR DESCRIPTION
### Motivation

- Provide a minimal, publishable, versioned documentation site so users can browse development and released docs for the project. 
- Keep changes small and non-invasive while enabling automatic GitHub Pages deployment for `main` and tag releases. 
- Ensure the docs build is strict and fails CI if API imports or docstring rendering fail so docs remain correct over time.

### Description

- Added `mkdocs.yml` configured with the Material theme, `search`, `mkdocstrings` (Python handler with `docstring_style: google`), `extra.version.provider: mike`, and `site_url` set for GitHub Pages. 
- Added a small `docs/` tree with `index.md`, `getting-started.md`, and `reference.md`, where `reference.md` uses `::: core.common` (mkdocstrings) to render the API docs from the actual package import path. 
- Added `requirements-docs.txt` listing `mkdocs-material`, `mkdocstrings[python]`, `mike`, and small runtime helpers, and updated `README.md` with a concise local docs workflow (`pip install -r requirements-docs.txt`, `export PYTHONPATH="$PWD"`, `mkdocs serve`, `mike deploy`). 
- Added a GitHub Actions workflow `.github/workflows/docs.yml` that triggers on pushes to `main` and tags `v*`, uses `actions/checkout@v4` with `fetch-depth: 0`, installs the docs deps, verifies `mkdocstrings` can import modules using `PYTHONPATH`, runs `mkdocs build --strict`, deploys dev docs on `main` with `mike deploy --push dev`, deploys versioned docs on tags by extracting `<major>.<minor>` from `vX.Y.Z` and running `mike deploy --push --update-aliases <maj.min> latest` and `mike set-default --push latest`, and performs a smoke test that checks the gh-pages output using a `git worktree` to ensure `site/<version>` and `site/latest` exist.

### Testing

- `python -m pip install -r requirements-docs.txt` completed successfully and installed the required documentation tools. 
- `PYTHONPATH=$PWD python -c "import core.common; print(core.common.__name__)"` succeeded, validating that mkdocstrings can import the module when `PYTHONPATH` is set. 
- `PYTHONPATH=$PWD mkdocs build --strict` completed successfully and produced a `site/` directory, validating the strict docs build; CI smoke tests for tag builds are included in the workflow to run on the Actions runners.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698196dab1f083328ac791eb550e4cc7)